### PR TITLE
Fix kai chat display and elara duplicate greetings

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -8,6 +8,7 @@ let chatHistory = [];
 let activeAgent = "Elara";
 let activeBackgroundAgents = new Set();
 let currentTheme = 'light';
+let hasShownGreeting = false;
 
 // Agent configurations
 const AGENTS = {
@@ -353,6 +354,7 @@ async function loadChatInterface(isNewSession = false, metrics = null) {
   if (isNewSession) {
     currentSessionId = null;
     chatHistory = [];
+    hasShownGreeting = false;
   }
   
   loadInterface(`<div class="chat-container" id="chat-log">
@@ -363,7 +365,7 @@ async function loadChatInterface(isNewSession = false, metrics = null) {
     <button class="btn btn-primary" onclick="sendMessage()">Send</button>
   </div>`);
   
-  if (isNewSession && metrics) {
+  if (isNewSession && metrics && !hasShownGreeting) {
     try {
       const res = await fetch(`${BACKEND_URL}/elara/greeting`, {
         method: 'POST',
@@ -375,9 +377,11 @@ async function loadChatInterface(isNewSession = false, metrics = null) {
         const data = await res.json();
         currentSessionId = data.sessionId;
         addBubble(data.response, 'elara');
+        hasShownGreeting = true;
       }
     } catch (error) {
       addBubble("Hello! I'm Elara, your AI companion. How are you feeling today?", 'elara');
+      hasShownGreeting = true;
     }
   }
 }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -751,7 +751,10 @@ body {
   padding: 2rem;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
-  min-height: 100vh;
+  /* Fit within the main chat area below the agent header */
+  min-height: 100%;
+  height: 100%;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
Fixes Kai chat screening UI overlap and prevents duplicate Elara greeting messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-2da8c987-aa20-4ec4-bfc8-12aae120c796">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2da8c987-aa20-4ec4-bfc8-12aae120c796">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

